### PR TITLE
Pass topic (destination) directly from subscribe to consume method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,4 @@ group :development do
   gem 'rake'
   gem 'rspec'
   gem 'rspec-its'
-  gem 'pry'
-  gem 'debugger', :platform => :mri
-  gem 'debugger-pry', :platform => :mri
 end

--- a/lib/stapfen/client/kafka.rb
+++ b/lib/stapfen/client/kafka.rb
@@ -71,8 +71,7 @@ module Stapfen
       #
       # @params [block] block to yield consumed messages
       def subscribe(destination, headers={}, &block)
-        destination = Stapfen::Destination.from_string(destination)
-        connection.consume(destination.as_kafka, &block)
+        connection.consume(destination, &block)
       end
 
       def runloop

--- a/lib/stapfen/version.rb
+++ b/lib/stapfen/version.rb
@@ -1,3 +1,3 @@
 module Stapfen
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end

--- a/lib/stapfen/worker.rb
+++ b/lib/stapfen/worker.rb
@@ -139,7 +139,7 @@ module Stapfen
     end
 
     def stomp?
-      @protocol.nil? || @protocol == STOMP
+      @protocol == STOMP
     end
 
     # Force the worker to use JMS as the messaging protocol.
@@ -194,16 +194,23 @@ module Stapfen
       @protocol == KAFKA
     end
 
+    def protocol
+      @protocol ||= KAFKA
+    end
+
     def run
-      if stomp?
+      case protocol
+      when STOMP
         require 'stapfen/client/stomp'
         stapfen_client = Stapfen::Client::Stomp.new(client_options)
-      elsif jms?
+      when JMS
         require 'stapfen/client/jms'
         stapfen_client = Stapfen::Client::JMS.new(client_options)
-      elsif kafka?
+      when KAFKA
         require 'stapfen/client/kafka'
         stapfen_client = Stapfen::Client::Kafka.new(client_options)
+      else
+        raise 'No client specified'
       end
 
       logger.info("Running with #{stapfen_client} inside of Thread:#{Thread.current.inspect}")

--- a/spec/client/kafka_spec.rb
+++ b/spec/client/kafka_spec.rb
@@ -84,15 +84,12 @@ describe Stapfen::Client::Kafka, :java => true do
 
   describe '#subscribe' do
     let(:topic) { 'topic' }
-    let(:destination) { double('Destination') }
     let(:msg) { 'foo' }
     it 'yields to the block and passes in consumed message' do
-      allow(destination).to receive(:as_kafka) { topic }
-      allow(Stapfen::Destination).to receive(:from_string) { destination }
       allow(consumer).to receive(:consume).with(topic).and_yield(msg)
 
       expect{ |b|
-        client.subscribe(destination, nil, &b)
+        client.subscribe(topic, nil, &b)
       }.to yield_with_args(msg)
     end
   end

--- a/spec/client/kafka_spec.rb
+++ b/spec/client/kafka_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'hermann/consumer'
 require 'stapfen/client/kafka'
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,11 +6,9 @@ require 'rspec/its'
 
 is_java = (RUBY_PLATFORM == 'java')
 
-unless is_java
-  require 'debugger'
-  require 'debugger/pry'
+if is_java
+  require 'hermann/consumer'
 end
-
 
 RSpec.configure do |c|
   c.color = true


### PR DESCRIPTION
Destination is unnecessary because the `as_kafka` method returned the topic anyway, so why bother with more code?